### PR TITLE
Fix item_key arg 

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -63,9 +63,9 @@ def evaluate_sessions_batch(pr, test_data, items=None, cut_off=20, batch_size=10
             break
         start_valid = start[valid_mask]
         minlen = (end[valid_mask]-start_valid).min()
-        in_idx[valid_mask] = test_data.ItemId.values[start_valid]
+        in_idx[valid_mask] = test_data[item_key].values[start_valid]
         for i in range(minlen-1):
-            out_idx = test_data.ItemId.values[start_valid+i+1]
+            out_idx = test_data[item_key].values[start_valid+i+1]
             if sampled_items:
                 uniq_out = np.unique(np.array(out_idx, dtype=np.int32))
                 preds = pr.predict_next_batch(iters, in_idx, np.hstack([items, uniq_out[~np.in1d(uniq_out,items)]]), batch_size)

--- a/gru4rec.py
+++ b/gru4rec.py
@@ -469,7 +469,7 @@ class GRU4Rec:
         train_function = function(inputs=[X, Y], outputs=cost, updates=updates, allow_input_downcast=True)
         base_order = np.argsort(data.groupby(self.session_key)[self.time_key].min().values) if self.time_sort else np.arange(len(offset_sessions)-1)
         if self.n_sample:
-            pop = data.groupby('ItemId').size()
+            pop = data.groupby(self.item_key).size()
             pop = pop[self.itemidmap.index.values].values**self.sample_alpha
             pop = pop.cumsum() / pop.sum()
             pop[-1] = 1


### PR DESCRIPTION
At this point if a developer uses the 'item_key' argument with a value other than 'ItemId', it can not create/evaluate a model correctly.

This pull request solves the problem.